### PR TITLE
Feature: read / write to any json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A utility knife for interacting with package.json
 
 ## Local (recommended)
 
-```
+```sh
 npm install boxcutter --save
 ```
 
 ## Global
 
-```
+```sh
 sudo npm install boxcutter -g
 ```
 
@@ -22,26 +22,38 @@ sudo npm install boxcutter -g
 
 ## CLI
 
-Walks up your directory tree looking for a package.json. If it finds one, it will load it
+Walks up your directory tree looking for a `package.json` file. If it finds one, it will load it
 and allow you to interact with it:
 
-```
+```sh
 Usage: boxcutter <command>
   available commands:
-    get            : get a value from the package.json
-    set            : set a value in the package.json
-    help <command> : get help for the specified command
+    get               : get a value from the package.json
+    set               : set a value in the package.json
+    help <command>    : get help for the specified command
+  options:
+    --indent <num>    : will indent json output the specified number of spaces
+    --file <filename> : will use specified json as input / output file
 ```
 
 Example:
 
-```
+```sh
 > boxcutter get version
 1.0.0
 > boxcutter set version 1.0.1
 > boxcutter get version
 1.0.1
 >
+```
+
+You may optionally use the `--file` flag to specify a json file other than `package.json`:
+```sh
+> boxcutter --file apidoc.json get name
+Boxcutter
+> boxcutter --file apidoc.json set name "Boxcutter API Documentation"
+> boxcutter --file apidoc.json get name
+Boxcutter API Documentation
 ```
 
 ## API

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ const argv = require( 'yargs' )
 
 const Boxcutter = require( './index.js' );
 const path = require( 'path' );
+const fs = require( 'fs' );
 
 let boxcutter = Object.assign( {}, Boxcutter.Boxcutter );
 
@@ -17,13 +18,28 @@ const directory = process.cwd();
 let directoryElements = directory.split( path.sep );
 let loaded = false;
 
-let packageFile = null;
+let jsonFile = null;
 
 do {
-    packageFile = path.sep + path.join.apply( path, directoryElements.concat( [ 'package.json' ] ) );
+    if ( argv.file ) {
+        // if `--file` option used, check that file actually exists
+        try {
+            if ( fs.statSync( argv.file ).isFile() ) {
+                jsonFile = path.sep + path.join.apply( path, directoryElements.concat( [ `${argv.file}` ] ) );
+            }
+        } catch ( ex ) {
+            console.error( ex );
+            process.exit( 1 );
+        }
 
+    } else {
+        // if no `--file` option, we assume `package.json`
+        jsonFile = path.sep + path.join.apply( path, directoryElements.concat( [ 'package.json' ] ) );
+    }
+
+    // attempt loading file into boxcutter
     try {
-        boxcutter.load( packageFile );
+        boxcutter.load( jsonFile );
         loaded = true;
     }
     catch( ex ) {
@@ -57,7 +73,7 @@ const commands = {
         const value = argv._.shift();
 
         boxcutter.set( key, value );
-        boxcutter.save( packageFile, function( error ) {
+        boxcutter.save( jsonFile, function( error ) {
             if ( error ) {
                 console.error( error );
                 process.exit( 1 );

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,6 @@ const argv = require( 'yargs' )
 
 const Boxcutter = require( './index.js' );
 const path = require( 'path' );
-const fs = require( 'fs' );
 
 let boxcutter = Object.assign( {}, Boxcutter.Boxcutter );
 

--- a/cli.js
+++ b/cli.js
@@ -18,26 +18,13 @@ const directory = process.cwd();
 let directoryElements = directory.split( path.sep );
 let loaded = false;
 
+const jsonFileName = argv.file ? argv.file : 'package.json';
 let jsonFile = null;
 
 do {
-    if ( argv.file ) {
-        // if `--file` option used, check that file actually exists
-        try {
-            if ( fs.statSync( argv.file ).isFile() ) {
-                jsonFile = path.sep + path.join.apply( path, directoryElements.concat( [ `${argv.file}` ] ) );
-            }
-        } catch ( ex ) {
-            console.error( ex );
-            process.exit( 1 );
-        }
 
-    } else {
-        // if no `--file` option, we assume `package.json`
-        jsonFile = path.sep + path.join.apply( path, directoryElements.concat( [ 'package.json' ] ) );
-    }
+    jsonFile = path.sep + path.join.apply( path, directoryElements.concat( [ jsonFileName ] ) );
 
-    // attempt loading file into boxcutter
     try {
         boxcutter.load( jsonFile );
         loaded = true;
@@ -47,6 +34,11 @@ do {
     }
 
 } while( !loaded && directoryElements.pop() );
+
+if ( !loaded ) {
+    console.error( `Could not locate file ${jsonFileName} in directory ancestry tree.` );
+    process.exit( 1 );
+}
 
 const command = argv._.shift();
 

--- a/help.json
+++ b/help.json
@@ -1,9 +1,13 @@
 {
     "usage": [
         "Usage: boxcutter <command>",
-        "  commands: get, set, help",
+        "  available commands:",
+        "    get               : get a value from the package.json",
+        "    set               : set a value in the package.json",
+        "    help <command>    : get help for the specified command",
         "  options:",
-        "    --indent <num> : will indent json output the specified number of spaces"
+        "    --indent <num>    : will indent json output the specified number of spaces",
+        "    --file <filename> : will use specified json as input / output file"
     ],
 
     "commands": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxcutter",
-  "version": "1.0.5",
+  "version": "1.1.5",
   "description": "A utility knife for interacting with package.json",
   "main": "index.js",
   "bin": {
@@ -9,17 +9,30 @@
   "scripts": {
     "test": "tape test/*.js | tap-spec"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andyburke/boxcutter.git"
+  },
   "keywords": [
     "package.json"
   ],
-  "author": "Andy Burke <aburke@bitflood.org>",
+  "author": "Andy Burke <aburke@bitflood.org> (https://github.com/andyburke)",
+  "contributors": [
+    "Greg Cardoni <greg@cardoni.net> (https://cardoni.net)"
+  ],
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/andyburke/boxcutter/issues"
+  },
+  "homepage": "https://github.com/andyburke/boxcutter#readme",
+  "engine": "node >= 4.3.0",
   "dependencies": {
     "delver": "^1.1.0",
     "extend": "^3.0.0",
     "yargs": "^4.2.0"
   },
   "devDependencies": {
+    "tap-spec": "^4.1.1",
     "tape": "^4.4.0"
   }
 }

--- a/test/02_cli.js
+++ b/test/02_cli.js
@@ -4,7 +4,6 @@ const child_process = require( 'child_process' );
 const test = require( 'tape' );
 
 const pkg = require( '../package.json' );
-// const jsonFile = require( './another_file.json' );
 const help = require( '../help.json' );
 
 let cli = null;
@@ -24,7 +23,7 @@ test( 'CLI: boxcutter package.json', t => {
 test( 'CLI: execute without arguments', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli ] );
-    t.error( result.error, 'Executed' );
+    t.ok( result.status, 'Executed' );
     t.ok( result.stderr && result.stderr.toString().length, 'Outputs usage' );
     t.equal( result.stderr.toString().trim(), help.usage.concat( [
         '',
@@ -37,7 +36,7 @@ test( 'CLI: execute without arguments', t => {
 test( 'CLI: execute help with no arguments', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help' ] );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Outputs help' );
     t.equal( result.stdout.toString().trim(), help.commands[ 'unknown command' ].join( '\n' ), 'Help output is correct' );
 
@@ -47,7 +46,7 @@ test( 'CLI: execute help with no arguments', t => {
 test( 'CLI: execute help on unknown command', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'foo' ] );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stderr && result.stderr.toString().length, 'Outputs help error' );
     t.equal( result.stderr.toString().slice( 0, -1 ), [ 'Unknown command: foo' ].concat( help.commands[ 'unknown command' ] ).join( '\n' ), 'Help error output is correct' );
 
@@ -57,7 +56,7 @@ test( 'CLI: execute help on unknown command', t => {
 test( 'CLI: execute help on get', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'get' ] );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Outputs help' );
     t.equal( result.stdout.toString().slice( 0, -1 ), help.commands.get.join( '\n' ), 'Help output is correct' );
 
@@ -67,7 +66,7 @@ test( 'CLI: execute help on get', t => {
 test( 'CLI: execute help on set', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'set' ] );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Outputs help' );
     t.equal( result.stdout.toString().slice( 0, -1 ), help.commands.set.join( '\n' ), 'Help output is correct' );
 
@@ -80,7 +79,7 @@ test( 'CLI: execute "get version"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'version' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), localPackage.version, 'Outputs correct version' );
 
@@ -93,7 +92,7 @@ test( 'CLI: execute "get config"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'config' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( localPackage.config, null, 2 ), 'Outputs correct config' );
 
@@ -106,7 +105,7 @@ test( 'CLI: execute "get config.test"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'config.test' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), localPackage.config.test, 'Outputs correct config.test value' );
 
@@ -119,7 +118,7 @@ test( 'CLI: execute "get array"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( localPackage.array, null, 2 ), 'Outputs correct array value' );
 
@@ -132,7 +131,7 @@ test( 'CLI: execute "get array[ 0 ]"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array[ 0 ]' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), '' + localPackage.array[ 0 ], 'Outputs correct value' );
 
@@ -145,7 +144,7 @@ test( 'CLI: execute "get array[ 1 ]"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array[ 1 ]' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), '' + localPackage.array[ 1 ], 'Outputs correct value' );
 
@@ -158,7 +157,7 @@ test( 'CLI: execute "--file another_file.json get version"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'version' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), jsonFile.version, 'Outputs correct version' );
 
@@ -171,7 +170,7 @@ test( 'CLI: execute "--file another_file.json get test.config"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.config' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( jsonFile.test.config, null, 2 ), 'Outputs correct config' );
 
@@ -184,7 +183,7 @@ test( 'CLI: execute "--file another_file.json get test.config.test"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.config.test' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), jsonFile.test.config.test, 'Outputs correct test.config.test value' );
 
@@ -197,7 +196,7 @@ test( 'CLI: execute "--file another_file.json get test.array"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( jsonFile.test.array, null, 2 ), 'Outputs correct array value' );
 
@@ -210,7 +209,7 @@ test( 'CLI: execute "--file another_file.json get test.array[ 0 ]"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array[ 0 ]' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), '' + jsonFile.test.array[ 0 ], 'Outputs correct value' );
 
@@ -223,9 +222,20 @@ test( 'CLI: execute "--file another_file.json get test.array[ 1 ]"', t => {
     const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array[ 1 ]' ], {
         cwd: __dirname
     } );
-    t.error( result.error, 'Executed' );
+    t.error( result.status, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), '' + jsonFile.test.array[ 1 ], 'Outputs correct value' );
+
+    t.end();
+} );
+
+test( 'CLI: calling nonexistent file fails' , t => {
+
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'nonexistent.json', 'get', 'test.array[ 1 ]' ], {
+        cwd: __dirname
+    } );
+
+    t.ok( result.status, 'Error when called with nonexistent file' );
 
     t.end();
 } );

--- a/test/02_cli.js
+++ b/test/02_cli.js
@@ -4,12 +4,13 @@ const child_process = require( 'child_process' );
 const test = require( 'tape' );
 
 const pkg = require( '../package.json' );
+// const jsonFile = require( './another_file.json' );
 const help = require( '../help.json' );
 
 let cli = null;
 
-test( 'CLI: boxcutter package.json', function( t ) {
-    t.ok( pkg, 'Read boxcutter pacakge.json' );
+test( 'CLI: boxcutter package.json', t => {
+    t.ok( pkg, 'Read boxcutter package.json' );
     t.ok( pkg.bin, 'Has bin' );
     t.ok( pkg.bin.boxcutter, 'Has boxcutter cli' );
 
@@ -20,7 +21,7 @@ test( 'CLI: boxcutter package.json', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute without arguments', function( t ) {
+test( 'CLI: execute without arguments', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli ] );
     t.error( result.error, 'Executed' );
@@ -33,7 +34,7 @@ test( 'CLI: execute without arguments', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute help with no arguments', function( t ) {
+test( 'CLI: execute help with no arguments', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help' ] );
     t.error( result.error, 'Executed' );
@@ -43,7 +44,7 @@ test( 'CLI: execute help with no arguments', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute help on unknown command', function( t ) {
+test( 'CLI: execute help on unknown command', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'foo' ] );
     t.error( result.error, 'Executed' );
@@ -53,7 +54,7 @@ test( 'CLI: execute help on unknown command', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute help on get', function( t ) {
+test( 'CLI: execute help on get', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'get' ] );
     t.error( result.error, 'Executed' );
@@ -63,7 +64,7 @@ test( 'CLI: execute help on get', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute help on set', function( t ) {
+test( 'CLI: execute help on set', t => {
 
     const result = child_process.spawnSync( process.execPath, [ cli, 'help', 'set' ] );
     t.error( result.error, 'Executed' );
@@ -73,7 +74,7 @@ test( 'CLI: execute help on set', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get version"', function( t ) {
+test( 'CLI: execute "get version"', t => {
 
     const localPackage = require( './package.json' );
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'version' ], {
@@ -86,7 +87,7 @@ test( 'CLI: execute "get version"', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get config"', function( t ) {
+test( 'CLI: execute "get config"', t => {
 
     const localPackage = require( './package.json' );
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'config' ], {
@@ -99,7 +100,7 @@ test( 'CLI: execute "get config"', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get config.test"', function( t ) {
+test( 'CLI: execute "get config.test"', t => {
 
     const localPackage = require( './package.json' );
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'config.test' ], {
@@ -112,7 +113,7 @@ test( 'CLI: execute "get config.test"', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get array"', function( t ) {
+test( 'CLI: execute "get array"', t => {
 
     const localPackage = require( './package.json' );
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array' ], {
@@ -125,10 +126,10 @@ test( 'CLI: execute "get array"', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get array[0]"', function( t ) {
+test( 'CLI: execute "get array[ 0 ]"', t => {
 
     const localPackage = require( './package.json' );
-    const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array[0]' ], {
+    const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array[ 0 ]' ], {
         cwd: __dirname
     } );
     t.error( result.error, 'Executed' );
@@ -138,7 +139,7 @@ test( 'CLI: execute "get array[0]"', function( t ) {
     t.end();
 } );
 
-test( 'CLI: execute "get \"array[ 1 ]\""', function( t ) {
+test( 'CLI: execute "get array[ 1 ]"', t => {
 
     const localPackage = require( './package.json' );
     const result = child_process.spawnSync( process.execPath, [ cli, 'get', 'array[ 1 ]' ], {
@@ -147,6 +148,84 @@ test( 'CLI: execute "get \"array[ 1 ]\""', function( t ) {
     t.error( result.error, 'Executed' );
     t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
     t.equal( result.stdout.toString().slice( 0, -1 ), '' + localPackage.array[ 1 ], 'Outputs correct value' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get version"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'version' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), jsonFile.version, 'Outputs correct version' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get test.config"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.config' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( jsonFile.test.config, null, 2 ), 'Outputs correct config' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get test.config.test"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.config.test' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), jsonFile.test.config.test, 'Outputs correct test.config.test value' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get test.array"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), JSON.stringify( jsonFile.test.array, null, 2 ), 'Outputs correct array value' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get test.array[ 0 ]"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array[ 0 ]' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), '' + jsonFile.test.array[ 0 ], 'Outputs correct value' );
+
+    t.end();
+} );
+
+test( 'CLI: execute "--file another_file.json get test.array[ 1 ]"', t => {
+
+    const jsonFile = require( './another_file.json' );
+    const result = child_process.spawnSync( process.execPath, [ cli, '--file', 'another_file.json', 'get', 'test.array[ 1 ]' ], {
+        cwd: __dirname
+    } );
+    t.error( result.error, 'Executed' );
+    t.ok( result.stdout && result.stdout.toString().length, 'Gets value' );
+    t.equal( result.stdout.toString().slice( 0, -1 ), '' + jsonFile.test.array[ 1 ], 'Outputs correct value' );
 
     t.end();
 } );

--- a/test/another_file.json
+++ b/test/another_file.json
@@ -1,0 +1,33 @@
+{
+  "name": "boxcutter-another-json-file-test",
+  "version": "1.2.3",
+  "description": "A utility knife for interacting with package.json (and other json files via CLI)",
+  "main": "index.js",
+  "bin": {
+    "boxcutter": "./cli.js"
+  },
+  "keywords": [
+    "package.json"
+  ],
+  "author": "Greg Cardoni <greg@cardoni.net> (https://cardoni.net)",
+  "license": "MIT",
+  "dependencies": {
+    "delver": "^1.0.0",
+    "yargs": "^4.2.0"
+  },
+  "test": {
+    "config": {
+      "test": "FOO",
+      "deep": {
+        "test": "BAR"
+      }
+    },
+    "array": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ]
+  }
+}


### PR DESCRIPTION
## Adds

Ability for CLI to optionally take a `--file` flag, specifying a json file other than `package.json`:

Example:

``` sh
> boxcutter --file apidoc.json get name
Boxcutter
> boxcutter --file apidoc.json set name "Boxcutter API Documentation"
> boxcutter --file apidoc.json get name
Boxcutter API Documentation
```
### Includes
- Additional tests for this new feature
- Updated readme w/ instructions
- Various improvements to `package.json`
